### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "viewport": "^0.1.6"
   },
   "devDependencies": {
-    "serve": "jkroso/serve#1.5.1"
+
   },
   "repository": "git://github.com/jkroso/flowtype.git",
   "bugs": "https://github.com/jkroso/flowtype/issues",


### PR DESCRIPTION
A clean install of flowtype doesn't work.
To fix this I've:
- updated the dependecies
- removed 'serve' as a dev dependency because it requires a global install. Maybe mention in the documentation that that serve is required globally?
