### PR TITLE
resize on hash changes for SPAs

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,5 +34,6 @@ module.exports = function(el, options){
   }
 
   viewport.on('resize', resize)
+  window.onhashchange = resize
   resize()
 }


### PR DESCRIPTION
`resize()` wasn't being called on hash changes, which often happens in SPA style web apps. Added `resize()` on `window.onhashchange`.